### PR TITLE
(37364) Странно отображается информация по пакету sysklogd

### DIFF
--- a/app/controllers/concerns/srpmable.rb
+++ b/app/controllers/concerns/srpmable.rb
@@ -5,10 +5,9 @@ module Srpmable
       @spkgs = Package::Src.by_name(params[:reponame])
                           .by_evr(@evrb)
                           .joins(:branches, :branch_paths)
-                          .merge(BranchPath.published)
                           .order({version: :desc,
                                   release: :desc,
-                                  buildtime: :desc},
+                                  buildtime: :asc},
                                  "branches.order_id")
 
       @spkg = @spkgs.in_branch(@branch).first&.decorate
@@ -17,10 +16,9 @@ module Srpmable
          rpms = Rpm.joins(:package, :branch_path, :branch)
                    .by_name(params[:reponame])
                    .by_evr(@evrb)
-                   .merge(BranchPath.published)
                    .order({"packages.version": :desc,
                            "packages.release": :desc,
-                           "packages.buildtime": :desc},
+                           "packages.buildtime": :asc},
                            "branches.order_id")
 
          if (branch = rpms.first&.branch) && branch != @branch
@@ -35,11 +33,10 @@ module Srpmable
       @spkgs_by_name = SrpmBranchesSerializer.new(Rpm.src
                                                      .by_name(params[:reponame])
                                                      .joins(:branch, :branch_path)
-                                                     .merge(BranchPath.published)
                                                      .includes(:branch_path, :branch, :package)
                                                      .order({"branches.order_id": :desc,
                                                              "packages.version": :desc,
                                                              "packages.release": :desc,
-                                                             "packages.buildtime": :desc}))
+                                                             "packages.buildtime": :asc}))
    end
 end

--- a/app/helpers/srpms_helper.rb
+++ b/app/helpers/srpms_helper.rb
@@ -65,16 +65,19 @@ module SrpmsHelper
          popup: _('Patches'),
          args: {controller: :patches, action: :index, branch: branch.slug, reponame: srpm.name},
          popup: _('patches'),
+         valid: 'downloadable?'
       },
       sources: {
          popup: _('Sources'),
          args: {controller: :sources, action: :index, branch: branch.slug, reponame: srpm.name},
          popup: _('sources'),
+         valid: 'downloadable?'
       },
       download: {
          popup: _('Download'),
          args: {controller: :rpms, action: :index, branch: branch.slug, reponame: srpm.name},
          popup: _('download latest version'),
+         valid: 'downloadable?'
       },
       bugs: {
          title: _('Bugs') + ' (%s/%s)' % [opened_bugs.count, all_bugs.count],
@@ -85,7 +88,7 @@ module SrpmsHelper
          popup: _('Repocop'),
          args: {controller: :repocop_notes, action: :index, branch: branch.slug, reponame: srpm.name},
          popup: _('repocop bugreports'),
-         valid: 'perpetual?'
+         valid: 'in_perpetual?'
       },
       repos: {
          title: _('Git Repos'),

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -210,6 +210,10 @@ class Package < ApplicationRecord
       read_attribute(:count)
    end
 
+   def rpm_in_branch branch
+      rpms.joins(:branch_path).where(branch_paths: { branch_id: branch.id }).first
+   end
+
    def self.source
       @source ||= self.to_s.split('::').last
    end

--- a/app/models/rpm.rb
+++ b/app/models/rpm.rb
@@ -28,7 +28,7 @@ class Rpm < ApplicationRecord
    end
 
    def ftp_url
-      File.join(branch_path.ftp_url, self.filename)
+      branch_path.ftp_url && File.join(branch_path.ftp_url, self.filename) || nil
    end
 
    def is_obsoleted?
@@ -46,6 +46,14 @@ class Rpm < ApplicationRecord
 
    def file_exists?
       File.exists?(filepath)
+   end
+
+   def in_perpetual?
+      branch.perpetual?
+   end
+
+   def downloadable?
+      !branch_path.ftp_url.nil?
    end
 
    protected

--- a/app/views/shared/_srpms_menu.html.slim
+++ b/app/views/shared/_srpms_menu.html.slim
@@ -1,6 +1,6 @@
 .page-menu
    - menu_data(branch, srpm, opened_bugs, all_bugs, evrb).each do |page, data|
-      - next if data[:valid] && !branch.send(data[:valid])
+      - next if data[:valid] && !srpm.rpm_in_branch(branch).send(data[:valid])
       .tab
          - if page == current_page
             span = _(data[:title])


### PR DESCRIPTION
* srpms sort in buildtime to asc order
- filter for unpublished branches
+ hide some tabs on the srpms page when srpms isn't downloadable